### PR TITLE
Travis support for tests in Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 install: "pip install -r requirements.txt --use-mirrors"
 script: "python -munittest tests"


### PR DESCRIPTION
As in the title - configuring Travis to run tests for Python 3.4 too.
