### PR TITLE
add clock and window parameters to totp

### DIFF
--- a/onetimepass/__init__.py
+++ b/onetimepass/__init__.py
@@ -130,6 +130,7 @@ def get_totp(
         digest_method=hashlib.sha1,
         token_length=6,
         interval_length=30,
+        clock=-1
 ):
     """Get time-based one-time password on the basis of given secret and time.
 
@@ -143,6 +144,8 @@ def get_totp(
     :type token_length: int
     :param interval_length: length of TOTP interval (30 seconds by default)
     :type interval_length: int
+    :param clock: clock time in epoch seconds to generate the totp for, default is Now (any number less than 0) 
+    :type clock: number
     :return: generated TOTP token
     :rtype: int or str
 
@@ -153,7 +156,9 @@ def get_totp(
         get_totp(b'MFRGGZDFMZTWQ2LK', as_string=True)
     False
     """
-    interv_no = int(time.time()) // interval_length
+    if clock < 0 :
+        clock = time.time()
+    interv_no = int(clock) // interval_length
     return get_hotp(
         secret,
         intervals_no=interv_no,
@@ -217,6 +222,7 @@ def valid_totp(
         digest_method=hashlib.sha1,
         token_length=6,
         interval_length=30,
+        window=0
 ):
     """Check if given token is valid time-based one-time password for given
     secret.
@@ -231,6 +237,8 @@ def valid_totp(
     :type token_length: int
     :param interval_length: length of TOTP interval (30 seconds by default)
     :type interval_length: int
+    :param window: compensate for clock skew, number of intervals to check on each side of the current time. (default is 0 - only check the current clock time)
+    :type interval_length: int (positive)
     :return: True, if is valid token, False otherwise
     :rtype: bool
 
@@ -246,15 +254,17 @@ def valid_totp(
     >>> valid_totp(token + b'1', secret)
     False
     """
-    return _is_possible_token(
-        token,
-        token_length=token_length,
-    ) and int(token) == get_totp(
-        secret,
-        digest_method=digest_method,
-        token_length=token_length,
-        interval_length=interval_length,
-    )
+    if _is_possible_token( token, token_length=token_length):
+        for w in range(-window, window+1):
+            if int(token) == get_totp(
+                secret,
+                digest_method=digest_method,
+                token_length=token_length,
+                interval_length=interval_length,
+                clock=time.time()+(w*interval_length)
+            ):
+                return True
+    return False
 
 __all__ = [
     'get_hotp',

--- a/onetimepass/__init__.py
+++ b/onetimepass/__init__.py
@@ -145,7 +145,7 @@ def get_totp(
     :param interval_length: length of TOTP interval (30 seconds by default)
     :type interval_length: int
     :param clock: clock time in epoch seconds to generate the totp for, default is Now if None
-    :type clock: number
+    :type clock: int
     :return: generated TOTP token
     :rtype: int or str
 
@@ -223,7 +223,7 @@ def valid_totp(
         token_length=6,
         interval_length=30,
         clock=None,
-        window=0
+        window=0,
 ):
     """Check if given token is valid time-based one-time password for given
     secret.
@@ -239,7 +239,7 @@ def valid_totp(
     :param interval_length: length of TOTP interval (30 seconds by default)
     :type interval_length: int
     :param clock: clock time in epoch seconds to generate the totp for, default is Now if None
-    :type clock: number
+    :type clock: int
     :param window: compensate for clock skew, number of intervals to check on each side of the current time.
         (default is 0 - only check the current clock time)
     :type window: int (positive)

--- a/onetimepass/__init__.py
+++ b/onetimepass/__init__.py
@@ -130,7 +130,7 @@ def get_totp(
         digest_method=hashlib.sha1,
         token_length=6,
         interval_length=30,
-        clock=-1
+        clock=None,
 ):
     """Get time-based one-time password on the basis of given secret and time.
 
@@ -144,7 +144,7 @@ def get_totp(
     :type token_length: int
     :param interval_length: length of TOTP interval (30 seconds by default)
     :type interval_length: int
-    :param clock: clock time in epoch seconds to generate the totp for, default is Now (any number less than 0) 
+    :param clock: clock time in epoch seconds to generate the totp for, default is Now if None
     :type clock: number
     :return: generated TOTP token
     :rtype: int or str
@@ -156,7 +156,7 @@ def get_totp(
         get_totp(b'MFRGGZDFMZTWQ2LK', as_string=True)
     False
     """
-    if clock < 0 :
+    if clock is None :
         clock = time.time()
     interv_no = int(clock) // interval_length
     return get_hotp(
@@ -222,6 +222,7 @@ def valid_totp(
         digest_method=hashlib.sha1,
         token_length=6,
         interval_length=30,
+        clock=None,
         window=0
 ):
     """Check if given token is valid time-based one-time password for given
@@ -237,8 +238,11 @@ def valid_totp(
     :type token_length: int
     :param interval_length: length of TOTP interval (30 seconds by default)
     :type interval_length: int
-    :param window: compensate for clock skew, number of intervals to check on each side of the current time. (default is 0 - only check the current clock time)
-    :type interval_length: int (positive)
+    :param clock: clock time in epoch seconds to generate the totp for, default is Now if None
+    :type clock: number
+    :param window: compensate for clock skew, number of intervals to check on each side of the current time.
+        (default is 0 - only check the current clock time)
+    :type window: int (positive)
     :return: True, if is valid token, False otherwise
     :rtype: bool
 
@@ -255,13 +259,15 @@ def valid_totp(
     False
     """
     if _is_possible_token( token, token_length=token_length):
+        if clock is None :
+            clock = time.time()
         for w in range(-window, window+1):
             if int(token) == get_totp(
                 secret,
                 digest_method=digest_method,
                 token_length=token_length,
                 interval_length=interval_length,
-                clock=time.time()+(w*interval_length)
+                clock=int(clock)+(w*interval_length)
             ):
                 return True
     return False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -174,6 +174,41 @@ class TotpGenerationTestCase(TestCase):
         totp = get_totp(secret=secret, as_string=True)
         self.assertEqual(hotp, totp)
 
+    def test_generating_totp_at_specific_clock(self):
+        """
+        check if the totp can be generated for a specific clock
+        which is basically the same as hotp
+        """
+        secret = b'MFRGGZDFMZTWQ2LK'
+        hotp = get_hotp(secret=secret, intervals_no=int(time.time())//30,)
+        totp = get_totp(secret=secret, clock=None)
+        self.assertEqual(hotp, totp)
+
+        # hotp intervals minus 1
+        hotp = get_hotp(secret=secret, intervals_no=int(time.time())//30-1,)
+        #totp 30 seconds in the past
+        totp = get_totp(secret=secret, clock=(int(time.time())-30))
+        self.assertEqual(hotp, totp)
+
+    def test_validating_totp_with_a_window(self):
+        """
+        validate if a totp token falls within a certain window
+        """
+        secret = b'MFRGGZDFMZTWQ2LK'
+        totp = get_totp(secret=secret, clock=(int(time.time()-30)))
+        self.assertFalse(valid_totp(totp,secret))
+        self.assertTrue(valid_totp(totp,secret,window=1))
+
+        totp = get_totp(secret=secret, clock=(int(time.time()+30)))
+        self.assertFalse(valid_totp(totp,secret))
+        self.assertTrue(valid_totp(totp,secret,window=1))
+
+        totp = get_totp(secret=secret, clock=(int(time.time()-59)))
+        self.assertFalse(valid_totp(totp,secret))
+        self.assertFalse(valid_totp(totp,secret,window=1))
+        self.assertTrue(valid_totp(totp,secret,window=2))
+
+
 
 class TotpValidityTestCase(TestCase):
     """


### PR DESCRIPTION
extended the library to allow the time to be specified when requesting/verifying a TOTP time code - useful when trying to validate against a particular moment in the past/future and in testing clients. Also added a window parameter to TOTP verification - the window specifies how many intervals of tolerance to allow - a tolerence of 0 (the default) means the codes must fall in the same interval. The window extends in both directions - a window of 1 will have three valid codes: 1 interval behind, the current interval, and one interval ahead.